### PR TITLE
Update develop_si-airline.yml to include .sln file in subdirectory

### DIFF
--- a/.github/workflows/develop_si-airline.yml
+++ b/.github/workflows/develop_si-airline.yml
@@ -24,7 +24,7 @@ jobs:
           dotnet-version: '8.x'
 
       - name: Build with dotnet
-        run: dotnet build --configuration Release
+        run: dotnet build SIAirline/SIAirline.sln --configuration Release
 
       - name: dotnet publish
         run: dotnet publish -c Release -o ${{env.DOTNET_ROOT}}/myapp


### PR DESCRIPTION
The .yml file for deploying to Azure was misconfigured to build in the root dir, instead of the SIAirline subdir. Fixed build command to run from subdir and find VS .sln file.