### PR TITLE
Added DB connection string for production

### DIFF
--- a/SIAirline/SIAirline/appsettings.Production.json
+++ b/SIAirline/SIAirline/appsettings.Production.json
@@ -1,6 +1,6 @@
 {
   "ConnectionStrings": {
-    "MySqlConnection": "Server=localhost;Database=si;User Id=root;Password=;"
+    "DefaultConnection": "Server=airline-mysql.mysql.database.azure.com;port=3306;UserID=asterix;Password=JakaLozinka2025!;Database=airline-mysql;"
   },
   "Logging": {
     "LogLevel": {


### PR DESCRIPTION
The DB connection string was added into appsettings.Production.json. Additionally, the App Service on the server was configured to have the Production environment variable set so that the project can automatically take the production DB connection string.