### PR TITLE
Added API route to check for remote DB health

### DIFF
--- a/SIAirline/SIAirline/Controllers/HealthController.cs
+++ b/SIAirline/SIAirline/Controllers/HealthController.cs
@@ -1,0 +1,33 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using SIAirline.Data;
+
+namespace SIAirline.Controllers {
+    [Route("api/[controller]")]
+    [ApiController]
+    public class HealthController : ControllerBase 
+    {
+        private readonly ApplicationDbContext _context;
+
+        public HealthController(ApplicationDbContext context) 
+        {
+            _context = context;
+        }
+
+        [HttpGet("api/health")]
+        public IActionResult GetHealth() {
+            // Check if the database is reachable
+            try {
+                _context.Database.CanConnect();
+                return Ok(new {
+                    status = "Healthy",
+                    message = "Database connection is healthy"
+                });
+            }
+            catch (Exception ex) {
+                return StatusCode(StatusCodes.Status500InternalServerError, $"Database connection failed: {ex.Message}");
+            }
+        }
+
+    }
+}


### PR DESCRIPTION
An API route was added that returns a status message on the health of the remote DB. Connection to the remote DB is tested and returned as 200 OK if the DB connection is successful.

